### PR TITLE
mention libmagic system requirement in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ source nrp-cmd-venv/bin/activate
 uv pip install nrp-cmd
 ```
 
+Your system needs to have the `libmagic` library installed, check out the [pypi page](https://pypi.org/project/python-magic/) for installation instructions depending on your platform.
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
without it you get 

```
  File "/Users/marten/devel/temp/csnt_invenio/.venv-3-12/lib/python3.12/site-packages/magic/__init__.py", line 209, in <module>
    libmagic = loader.load_lib()
               ^^^^^^^^^^^^^^^^^
  File "/Users/marten/devel/temp/csnt_invenio/.venv-3-12/lib/python3.12/site-packages/magic/loader.py", line 49, in load_lib
    raise ImportError('failed to find libmagic.  Check your installation')
ImportError: failed to find libmagic.  Check your installation
```